### PR TITLE
Adding button to toggle Announce block

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,13 @@ edit_uri: edit/main/docs/
 
 copyright: None
 
-announce: None
+announce: 
+  text: None
+  toggle:
+    - label: Show info
+      icon: material/information-outline
+    - label: Hide info 
+      icon: material/information
 
 extra_css:
   - stylesheets/extra.css
@@ -72,9 +78,8 @@ extra:
     - icon: fontawesome/brands/x-twitter
       link: https://twitter.com/openstreetmap 
     - icon: fontawesome/brands/facebook
-      link: https://www.facebook.com/OpenStreetMap/
-
-
+      link: https://www.facebook.com/OpenStreetMap/  
+    
 # End of MkDocs theme adjastments
 
 markdown_extensions:
@@ -145,10 +150,16 @@ plugins:
           name: English
           default: true
           site_name: Welcome to OpenStreetMap
-          announce: >
-            <p>Welcome Mat for <a href="https://www.openstreetmap.org" target="_blank">OpenStreetMap</a> community and <a href="https://osmfoundation.org" target="_blank">Foundation</a>. OpenStreetMap is the free and editable map of the world, created and maintained by a huge international community. Anybody can create an account and start editing on <a href="https://www.openstreetmap.org" target="_blank">OpenStreetMap</a> within minutes.</p>
-            <p>These guides are licensed under <a href="http://creativecommons.org/licenses/by-sa/2.0/" target="_blank">Creative Commons Attribution-ShareAlike 2.0 Generic License</a> if you would like to contribute or have any feedback on these, please feel free to raise an issue in this <a href="https://github.com/osmfoundation/welcome-mat/issues" target="_blank">repository</a>.</p>
-          copyright: © 2019 – 2023 OpenStreetMap Foundation, <a rel="license" href="http://creativecommons.org/licenses/by-sa/2.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/2.0/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/2.0/" target="_blank">Creative Commons Attribution-ShareAlike 2.0 Generic License</a>.
+          announce:
+            toggle:
+              - label: Show info
+                icon: material/information-outline
+              - label: Hide info
+                icon: material/information
+            text: >-
+              <p>Welcome Mat for <a href="https://www.openstreetmap.org" target="_blank">OpenStreetMap</a> community and <a href="https://osmfoundation.org" target="_blank">Foundation</a>. OpenStreetMap is the free and editable map of the world, created and maintained by a huge international community. Anybody can create an account and start editing on <a href="https://www.openstreetmap.org" target="_blank">OpenStreetMap</a> within minutes.</p>
+              <p>These guides are licensed under <a href="http://creativecommons.org/licenses/by-sa/2.0/" target="_blank">Creative Commons Attribution-ShareAlike 2.0 Generic License</a> if you would like to contribute or have any feedback on these, please feel free to raise an issue in this <a href="https://github.com/osmfoundation/welcome-mat/issues" target="_blank">repository</a>.</p>
+          copyright: © 2019 – 2023 OpenStreetMap Foundation, <a rel="license" href="http://creativecommons.org/licenses/by-sa/2.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/2.0/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/2.0/" target="_blank">Creative Commons Attribution-ShareAlike 2.0 Generic License</a>. <a href="#__consent">Change cookie settings</a>
           nav_translations:
             Home: Home
             # About: About us
@@ -178,10 +189,16 @@ plugins:
         - locale: uk
           name: Українська
           site_name: Ласкаво просимо до OpenStreetMap
-          announce: >
-            <p>Вітаємо вас у цьому посібнику спільноти <a href="https://www.openstreetmap.org" target="_blank">OpenStreetMap</a> та <a href="https://osmfoundation.org" target="_blank">Фундації</a> проєкту. OpenStreetMap – це вільна мапа світу покращувати яку може кожен, яка створена та підтримується зусиллями величезної міжнародної спільноти. Будь-хто може зареєструватись в проєкті та розпочати вносити свої зміни в <a href="https://www.openstreetmap.org" target="_blank">OpenStreetMap</a> за лічені хвилини.</p>
-            <p>Матеріали цього посібника розповсюджуються на умовах Ліцензії <a href="https://creativecommons.org/licenses/by-sa/2.0/deed.uk" target="_blank">Creative Commons Attribution-ShareAlike 2.0 Generic License</a> і якщо у вас є бажання взяти участь його вдосконалені, або у вас є побажання щодо його покращення, не соромтеся створити тікет у нашому <a href="https://github.com/osmfoundation/welcome-mat/issues" target="_blank">репозиторії</a>.</p>
-          copyright: "© 2019 – 2023 Фундація OpenStreetMap, <a rel=\"license\" href=\"https://creativecommons.org/licenses/by-sa/2.0/deed.uk\" target=\"_blank\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-sa/2.0/80x15.png\" /></a><br />Матеріали цього сайту ліцензуються на умовах Ліцензії – <a rel=\"license\" href=\"https://creativecommons.org/licenses/by-sa/2.0/deed.uk\" target=\"_blank\">Creative Commons Attribution-ShareAlike 2.0 Generic License</a>."
+          announce: 
+            toggle:
+              - label: Показати інформацію
+                icon: material/information-outline
+              - label: Приховати інформацію
+                icon: material/information
+            text: >-
+              <p>Вітаємо вас у цьому посібнику спільноти <a href="https://www.openstreetmap.org" target="_blank">OpenStreetMap</a> та <a href="https://osmfoundation.org" target="_blank">Фундації</a> проєкту. OpenStreetMap – це вільна мапа світу покращувати яку може кожен, яка створена та підтримується зусиллями величезної міжнародної спільноти. Будь-хто може зареєструватись в проєкті та розпочати вносити свої зміни в <a href="https://www.openstreetmap.org" target="_blank">OpenStreetMap</a> за лічені хвилини.</p>
+              <p>Матеріали цього посібника розповсюджуються на умовах Ліцензії <a href="https://creativecommons.org/licenses/by-sa/2.0/deed.uk" target="_blank">Creative Commons Attribution-ShareAlike 2.0 Generic License</a> і якщо у вас є бажання взяти участь його вдосконалені, або у вас є побажання щодо його покращення, не соромтеся створити тікет у нашому <a href="https://github.com/osmfoundation/welcome-mat/issues" target="_blank">репозиторії</a>.</p>
+          copyright: "© 2019 – 2023 Фундація OpenStreetMap, <a rel=\"license\" href=\"https://creativecommons.org/licenses/by-sa/2.0/deed.uk\" target=\"_blank\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-sa/2.0/80x15.png\" /></a><br />Матеріали цього сайту ліцензуються на умовах Ліцензії – <a rel=\"license\" href=\"https://creativecommons.org/licenses/by-sa/2.0/deed.uk\" target=\"_blank\">Creative Commons Attribution-ShareAlike 2.0 Generic License</a>. <a href=\"#__consent\">Change cookie settings</a>"
           nav_translations:
             Home: Головна
             # About: Про нас

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div markdown>
-    {{ config.announce }}
-  </div>
+    <div markdown>
+        {{ config.announce.text }}
+    </div>
 {%- endblock %}

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -1,0 +1,95 @@
+<!-- Determine classes -->
+{% set class = "md-header" %}
+{% if "navigation.tabs.sticky" in features %}
+  {% set class = class ~ " md-header--shadow md-header--lifted" %}
+{% elif "navigation.tabs" not in features %}
+  {% set class = class ~ " md-header--shadow" %}
+{% endif %}
+
+<!-- Header -->
+<header class="{{ class }}" data-md-component="header">
+  <nav
+    class="md-header__inner md-grid"
+    aria-label="{{ lang.t('header') }}"
+  >
+
+    <!-- Link to home -->
+    <a
+      href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}"
+      title="{{ config.site_name | e }}"
+      class="md-header__button md-logo"
+      aria-label="{{ config.site_name }}"
+      data-md-component="logo"
+    >
+      {% include "partials/logo.html" %}
+    </a>
+
+    <!-- Button to open drawer -->
+    <label class="md-header__button md-icon" for="__drawer">
+      {% set icon = config.theme.icon.menu or "material/menu" %}
+      {% include ".icons/" ~ icon ~ ".svg" %}
+    </label>
+
+    <!-- Header title -->
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
+            {{ config.site_name }}
+          </span>
+        </div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
+            {% if page.meta and page.meta.title %}
+              {{ page.meta.title }}
+            {% else %}
+              {{ page.title }}
+            {% endif %}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Announce toggle -->
+    {% if config.announce %}
+        {% include "partials/info.html" %}
+    {% endif %}
+
+    <!-- Color palette toggle -->
+    {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+        {% include "partials/palette.html" %}
+      {% endif %}
+    {% endif %}
+
+    <!-- Site language selector -->
+    {% if config.extra.alternate %}
+      {% include "partials/alternate.html" %}
+    {% endif %}
+
+    <!-- Button to open search modal -->
+    {% if "material/search" in config.plugins %}
+      <label class="md-header__button md-icon" for="__search">
+        {% set icon = config.theme.icon.search or "material/magnify" %}
+        {% include ".icons/" ~ icon ~ ".svg" %}
+      </label>
+
+      <!-- Search interface -->
+      {% include "partials/search.html" %}
+    {% endif %}
+
+    <!-- Repository information -->
+    {% if config.repo_url %}
+      <div class="md-header__source">
+        {% include "partials/source.html" %}
+      </div>
+    {% endif %}
+  </nav>
+
+  <!-- Navigation tabs (sticky) -->
+  {% if "navigation.tabs.sticky" in features %}
+    {% if "navigation.tabs" in features %}
+      {% include "partials/tabs.html" %}
+    {% endif %}
+  {% endif %}
+</header>

--- a/overrides/partials/info.html
+++ b/overrides/partials/info.html
@@ -1,0 +1,27 @@
+<form class="md-header__option" data-md-component="info">
+  {% for option in config.announce.toggle %}
+  <input
+    class="md-option"
+    aria-label="{{ option.label }}" 
+    type="radio"
+    name="__info"
+    id="__info_{{ loop.index }}"
+          {% if loop.index != 1 %}
+    aria-hidden="true"
+          hidden
+    {% endif %}
+    />
+    <label
+      class="md-header__button md-icon"
+      title="{{ option.label }}"
+      for="__info_{{ loop.index }}"
+      {% if loop.index != 1 %}
+        hidden
+      {% endif %}
+    >
+      {% include ".icons/" ~ option.icon ~ ".svg" %}
+    </label>
+  {% endfor %}
+</form>
+
+{% include "partials/javascripts/info.html" %}

--- a/overrides/partials/javascripts/info.html
+++ b/overrides/partials/javascripts/info.html
@@ -1,0 +1,27 @@
+<script>
+    let announceBar = document.querySelector("[data-md-component=announce]");
+    let infoForm = document.querySelector("[data-md-component=info]");
+    let infoInputs = infoForm.querySelectorAll("input");
+    
+    let infoToggleHandler = (el) => {
+      for (input of infoInputs) {
+        let isHidden = input.hidden === true;
+        input.hidden = !isHidden;
+        if (isHidden) {
+          input.removeAttribute("aria-hidden");
+        } else {
+          input.setAttribute("aria-hidden", "true");
+        }
+        input.nextElementSibling.hidden = !isHidden;
+      }
+      announceBar.hidden = !announceBar.hidden;
+    };
+    
+    if (announceBar) {
+      announceBar.hidden = true;
+      for (input of infoInputs) {
+        input.addEventListener("click", infoToggleHandler);
+      }
+    }
+</script>
+    


### PR DESCRIPTION
This pull request introduces a button that allows toggling the Announce block, closely replicating the same button found on the original welcome.osm.org website. (Solution provided by @kamilkrzyskow in https://github.com/squidfunk/mkdocs-material/discussions/6097#discussioncomment-7200178)

See ℹ️ icon new day/night switcher

<img width="1442" alt="image" src="https://github.com/Andygol/welcome-mat-osmf/assets/369696/b3dfdcda-a716-438c-baa5-2005c28cdcd3">

Closes issue: #5 